### PR TITLE
Added error check for fan mode reload, to fix crash on load bug.

### DIFF
--- a/rog-core/src/daemon.rs
+++ b/rog-core/src/daemon.rs
@@ -53,7 +53,13 @@ pub async fn start_daemon() -> Result<(), Box<dyn Error>> {
     );
 
     // Reload settings
-    rogcore.fan_mode_reload(&mut config).await?;
+    let fan_mode_reload_ok = rogcore.fan_mode_reload(&mut config).await;
+
+    match fan_mode_reload_ok{
+        Ok(()) => (),
+        Err(e) => info!("Warning, failed reloading fan mode: {:?}", e),
+    };
+
     let mut led_writer = LedWriter::new(
         rogcore.get_raw_device_handle(),
         laptop.led_endpoint(),


### PR DESCRIPTION
This may well not be the best way to achieve this - as I've never programmed in rust before today, so I'm happy to be corrected. It would probably also be better if the fan modes could be made to work, rather than just ignore them not working. That said - this appears to allow the daemon to load on my machine, simply printing out an error message, and it then works perfectly for everything bar fan modes. So I thought it may be helpful to submit a pull for you to have a look at.