### PR TITLE
dbus cleanup

### DIFF
--- a/rog-core/src/daemon.rs
+++ b/rog-core/src/daemon.rs
@@ -11,7 +11,7 @@ use dbus::{channel::Sender, nonblock::Process};
 
 use dbus_tokio::connection;
 use log::{error, info, warn};
-use rog_aura::{DBUS_IFACE, DBUS_PATH};
+use rog_aura::{DBUS_NAME, DBUS_IFACE, DBUS_PATH};
 use std::error::Error;
 use std::sync::{mpsc, Arc};
 use std::time::{Duration, Instant};
@@ -82,7 +82,7 @@ pub async fn start_daemon() -> Result<(), Box<dyn Error>> {
     });
 
     connection
-        .request_name(DBUS_IFACE, false, true, true)
+        .request_name(DBUS_NAME, false, true, true)
         .await?;
 
     let (aura_command_send, aura_command_recv) = mpsc::sync_channel::<AuraCommand>(1);

--- a/rog-core/src/rog_dbus.rs
+++ b/rog-core/src/rog_dbus.rs
@@ -78,7 +78,7 @@ pub(super) fn dbus_create_ledeffect_method(effect: NestedVecType) -> Method<MTSy
                         iter.read()?,
                     ];
                     *lock = Some(byte_array);
-                    Ok(vec!(m.msg.method_return()))
+                    Ok(vec![])
                 } else {
                     Err(MethodErr::failed("Could not lock daemon for access"))
                 }
@@ -95,6 +95,7 @@ pub(super) fn dbus_create_ledeffect_method(effect: NestedVecType) -> Method<MTSy
         .inarg::<Vec<u8>, _>("bytearray9")
         .inarg::<Vec<u8>, _>("bytearray10")
         .inarg::<Vec<u8>, _>("bytearray11")
+        .annotate("org.freedesktop.DBus.Method.NoReply", "true")
 }
 
 pub(super) fn dbus_create_animatrix_method(effect: NestedVecType) -> Method<MTSync, ()> {
@@ -107,7 +108,7 @@ pub(super) fn dbus_create_animatrix_method(effect: NestedVecType) -> Method<MTSy
                     let mut iter = m.msg.iter_init();
                     let byte_array: Vec<Vec<u8>> = vec![iter.read()?, iter.read()?];
                     *lock = Some(byte_array);
-                    Ok(vec!(m.msg.method_return()))
+                    Ok(vec![])
                 } else {
                     Err(MethodErr::failed("Could not lock daemon for access"))
                 }
@@ -115,6 +116,7 @@ pub(super) fn dbus_create_animatrix_method(effect: NestedVecType) -> Method<MTSy
         })
         .inarg::<Vec<u8>, _>("bytearray1")
         .inarg::<Vec<u8>, _>("bytearray2")
+        .annotate("org.freedesktop.DBus.Method.NoReply", "true")
 }
 
 pub(super) fn dbus_create_fan_mode_method(fan_mode: FanModeType) -> Method<MTSync, ()> {

--- a/rog-core/src/rog_dbus.rs
+++ b/rog-core/src/rog_dbus.rs
@@ -157,7 +157,7 @@ pub(super) fn dbus_create_tree() -> (
     let factory = Factory::new_sync::<()>();
     let effect_cancel_sig = Arc::new(factory.signal("LedCancelEffect", ()));
     let tree = factory.tree(()).add(
-        factory.object_path(DBUS_PATH, ()).add(
+        factory.object_path(DBUS_PATH, ()).introspectable().add(
             factory
                 .interface(DBUS_IFACE, ())
                 .add_m(dbus_create_ledmsg_method(input_bytes.clone()))
@@ -167,7 +167,7 @@ pub(super) fn dbus_create_tree() -> (
                 .add_m(dbus_create_fan_mode_method(fan_mode.clone()))
                 .add_s(effect_cancel_sig.clone()),
         ),
-    );
+    ).add(factory.object_path("/", ()).introspectable());
     (
         tree,
         input_bytes,

--- a/rog-core/src/rog_dbus.rs
+++ b/rog-core/src/rog_dbus.rs
@@ -50,10 +50,10 @@ pub(super) fn dbus_create_ledmultizone_method(effect: NestedVecType) -> Method<M
             }
         })
         .outarg::<&str, _>("reply")
-        .inarg::<Vec<u8>, _>("bytearray")
-        .inarg::<Vec<u8>, _>("bytearray")
-        .inarg::<Vec<u8>, _>("bytearray")
-        .inarg::<Vec<u8>, _>("bytearray")
+        .inarg::<Vec<u8>, _>("bytearray1")
+        .inarg::<Vec<u8>, _>("bytearray2")
+        .inarg::<Vec<u8>, _>("bytearray3")
+        .inarg::<Vec<u8>, _>("bytearray4")
 }
 
 pub(super) fn dbus_create_ledeffect_method(effect: NestedVecType) -> Method<MTSync, ()> {
@@ -78,23 +78,23 @@ pub(super) fn dbus_create_ledeffect_method(effect: NestedVecType) -> Method<MTSy
                         iter.read()?,
                     ];
                     *lock = Some(byte_array);
-                    Ok(vec![])
+                    Ok(vec!(m.msg.method_return()))
                 } else {
                     Err(MethodErr::failed("Could not lock daemon for access"))
                 }
             }
         })
-        .inarg::<Vec<u8>, _>("bytearray")
-        .inarg::<Vec<u8>, _>("bytearray")
-        .inarg::<Vec<u8>, _>("bytearray")
-        .inarg::<Vec<u8>, _>("bytearray")
-        .inarg::<Vec<u8>, _>("bytearray")
-        .inarg::<Vec<u8>, _>("bytearray")
-        .inarg::<Vec<u8>, _>("bytearray")
-        .inarg::<Vec<u8>, _>("bytearray")
-        .inarg::<Vec<u8>, _>("bytearray")
-        .inarg::<Vec<u8>, _>("bytearray")
-        .inarg::<Vec<u8>, _>("bytearray")
+        .inarg::<Vec<u8>, _>("bytearray1")
+        .inarg::<Vec<u8>, _>("bytearray2")
+        .inarg::<Vec<u8>, _>("bytearray3")
+        .inarg::<Vec<u8>, _>("bytearray4")
+        .inarg::<Vec<u8>, _>("bytearray5")
+        .inarg::<Vec<u8>, _>("bytearray6")
+        .inarg::<Vec<u8>, _>("bytearray7")
+        .inarg::<Vec<u8>, _>("bytearray8")
+        .inarg::<Vec<u8>, _>("bytearray9")
+        .inarg::<Vec<u8>, _>("bytearray10")
+        .inarg::<Vec<u8>, _>("bytearray11")
 }
 
 pub(super) fn dbus_create_animatrix_method(effect: NestedVecType) -> Method<MTSync, ()> {
@@ -107,14 +107,14 @@ pub(super) fn dbus_create_animatrix_method(effect: NestedVecType) -> Method<MTSy
                     let mut iter = m.msg.iter_init();
                     let byte_array: Vec<Vec<u8>> = vec![iter.read()?, iter.read()?];
                     *lock = Some(byte_array);
-                    Ok(vec![])
+                    Ok(vec!(m.msg.method_return()))
                 } else {
                     Err(MethodErr::failed("Could not lock daemon for access"))
                 }
             }
         })
-        .inarg::<Vec<u8>, _>("bytearray")
-        .inarg::<Vec<u8>, _>("bytearray")
+        .inarg::<Vec<u8>, _>("bytearray1")
+        .inarg::<Vec<u8>, _>("bytearray2")
 }
 
 pub(super) fn dbus_create_fan_mode_method(fan_mode: FanModeType) -> Method<MTSync, ()> {


### PR DESCRIPTION
This PR includes a few things that are needed to be able to experiment using rog-core from python (or maybe other languages):
- Add the org.freedesktop.DBus.Introspectable interface
- Set different names for the arguments (or else python raises an exception when connecting)
- Add method_return()s where missing