### PR TITLE
Fix rebasing mistake

### DIFF
--- a/rog-core/src/daemon.rs
+++ b/rog-core/src/daemon.rs
@@ -11,7 +11,7 @@ use dbus::{channel::Sender, nonblock::Process};
 
 use dbus_tokio::connection;
 use log::{error, info, warn};
-use rog_aura::{DBUS_IFACE, DBUS_NAME, DBUS_PATH};
+use rog_client::{DBUS_IFACE, DBUS_NAME, DBUS_PATH};
 use std::error::Error;
 use std::sync::{mpsc, Arc};
 use std::time::{Duration, Instant};


### PR DESCRIPTION
I might have made a mistake when rebasing on your branch in the last PR... this uses the correct name and fixes the compilation error